### PR TITLE
fix problem of token missing and reading

### DIFF
--- a/src/quafu/users/_quafu_url.py
+++ b/src/quafu/users/_quafu_url.py
@@ -1,1 +1,0 @@
-QUAFU_URL = "https://quafu.baqis.ac.cn/"

--- a/src/quafu/users/exceptions.py
+++ b/src/quafu/users/exceptions.py
@@ -1,4 +1,17 @@
 from ..exceptions import QuafuError
 
+
 class UserError(QuafuError):
+    pass
+
+
+class APITokenNotFound(UserError):
+    pass
+
+
+class InvalidAPIToken(UserError):
+    pass
+
+
+class BackendNotAvailable(UserError):
     pass

--- a/src/quafu/users/userapi.py
+++ b/src/quafu/users/userapi.py
@@ -15,7 +15,7 @@ class User(object):
     exec_async_api = url + "qbackend/scq_kit_asyc/"
     exec_recall_api = url + "qbackend/scq_task_recall/"
 
-    def __init__(self, api_token: str = '', token_dir: str = None):
+    def __init__(self, api_token: str = None, token_dir: str = None):
         """
         Initialize user account and load backend information.
 
@@ -29,7 +29,7 @@ class User(object):
         else:
             self.token_dir = token_dir
 
-        if api_token == '':
+        if api_token is None:
             self._api_token = self._load_account_token()
         else:
             self._api_token = api_token
@@ -38,7 +38,7 @@ class User(object):
 
     @property
     def api_token(self):
-        if self._api_token == '':
+        if self._api_token is None:
             raise APITokenNotFound(f"API token not set, neither found at dir: '{self.token_dir}'. "
                                    "Please set up by providing api_token/token_dir when initializing User.")
         return self._api_token
@@ -70,7 +70,7 @@ class User(object):
         """
         file_dir = self.token_dir + "api"
         if not os.path.exists(file_dir):
-            return ''
+            return None
         else:
             f = open(file_dir, "r")
             token = f.readline().strip()


### PR DESCRIPTION
The forehead 'import' problem comes from default argument ``user=User()`` of ``Task.__init__``. Now ``user.api_token`` is written by ``@property`` and only raise exception when visited yet not set.