### PR TITLE
Update instruction.py

### DIFF
--- a/src/quafu/elements/quantum_element/instruction.py
+++ b/src/quafu/elements/quantum_element/instruction.py
@@ -17,7 +17,7 @@ from typing import Union, List
 
 
 PosType = Union[int, List[int]]
-ParaType = dict[str, Union[float, int]]
+ParaType = Union[float, int]
 
 
 class Instruction(ABC):


### PR DESCRIPTION
fix dict typing unsupported in py3.8