### PR TITLE
Add 'dev*.py' to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ cmake
 thirdparty
 *.so
 MANIFEST.in
-.pyd
+*.pyd
+dev*.py


### PR DESCRIPTION
I advise using this naming format for  files of personal/local test or development.