### PR TITLE
Stable/0.3: fix x-position bug of bar plot in plotting results

### DIFF
--- a/src/quafu/results/results.py
+++ b/src/quafu/results/results.py
@@ -99,7 +99,7 @@ class SimuResult(Result):
             reverse_basis: Whether reverse the bitstring of basis. (Little endian convention).
             sort:  Sort the results by probabilities values. Can be `"ascend"` order or `"descend"` order. 
         """
-
+        plt.close()
         probs = self.probabilities
         inds = range(len(probs))
         if not full:
@@ -120,7 +120,7 @@ class SimuResult(Result):
             basis = basis[orders][::-1]
 
         plt.figure()
-        plt.bar(inds, probs, tick_label=basis)
+        plt.bar(range(len(inds)), probs, tick_label=basis)
         plt.xticks(rotation=70)
         plt.ylabel("probabilities")
 


### PR DESCRIPTION
The former function ``plot_probabilities()`` use indices of states as x-position, this is ok when full results are plotted. Yet when setting ``full=False``, it works incorrectly. Consider the following example:
```python
inds = np.array([0, 128, 256, 384])
probs = np.array([0.25, 0.25, 0.25, 0.25])
basis = ['000000000' '010000000' '100000000' '110000000']
plt.bar(inds, probs, tick_label=basis)
plt.xticks(rotation=40)
plt.show()
```
This is purely a problem of plotting.