### PR TITLE
Stable/0.3: retrieving task if get empty counts in send(wait=True)

### DIFF
--- a/src/quafu/tasks/tasks.py
+++ b/src/quafu/tasks/tasks.py
@@ -248,7 +248,12 @@ class Task(object):
                 else:
                     self.submit_history[group].append(task_id)
 
-                return ExecResult(res_dict)
+                result = ExecResult(res_dict)
+                while wait and (self.shots > 0) and (not result.counts):
+                    if verbose:
+                        logging.warning('warning for quafu status: empty result.counts, retrieving task...')
+                    result = self.retrieve(result.taskid)
+                return result
 
     def retrieve(self, taskid: str) -> ExecResult:
         """

--- a/src/quafu/visualisation/circuitPlot.py
+++ b/src/quafu/visualisation/circuitPlot.py
@@ -206,8 +206,9 @@ class CircuitPlotManager:
         elif name in r2_gate_names:
             # TODO: combine into one box
             self._ctrl_wire_points.append([[depth, ins.pos[0]], [depth, ins.pos[1]]])
-            self._proc_su2(name[:-1], depth, ins.pos[0], paras)
-            self._proc_su2(name[:-1], depth, ins.pos[1], paras)
+
+            self._proc_su2(name[:-1], depth, min(ins.pos), None)
+            self._proc_su2(name[:-1], depth, max(ins.pos), paras)
         elif isinstance(ins, ControlledGate):
             self._proc_ctrl(depth, ins)
         elif name == 'delay':
@@ -363,7 +364,7 @@ class CircuitPlotManager:
 
         if id_name in ['rx', 'ry', 'rz', 'p']:
             # too long to display: r'$\theta=$' + f'{paras:.3f}' (TODO)
-            para_txt = f'({paras:.3f})'
+            para_txt = f'({paras:.3f})' if paras else None
         else:
             para_txt = None
 


### PR DESCRIPTION
For yet unkown reasons, empty ``counts`` occasionally recieved from the backend though in-time execution results were expected (``wait=True``). Now use ``retrieve()`` to **temporarily** relief  this problem. 