### PR TITLE
fix: openmp typo

### DIFF
--- a/src/qfvm/statevector.hpp
+++ b/src/qfvm/statevector.hpp
@@ -1303,7 +1303,7 @@ double StateVector<real_t>::expect_pauli(string paulistr,
     size_t rsize = size_;
     double val = 0.;
 #pragma omp parallel for reduction(+ : val)
-    for (int j = 0; j < rsize; ++j) {
+    for (omp_i j = 0; j < rsize; ++j) {
       uint z_phase_num = Qfutil::popcount(j & z_mask) % 2;
       int sign = 1 - 2 * z_phase_num;
       val += (data_[j] * std::conj(data_[j])).real() * sign;
@@ -1313,7 +1313,7 @@ double StateVector<real_t>::expect_pauli(string paulistr,
     double val = 0.;
     size_t rsize = size_ >> 1;
 #pragma omp parallel for reduction(+ : val)
-    for (int j = 0; j < rsize; ++j) {
+    for (omp_i j = 0; j < rsize; ++j) {
       size_t i0 = (j & ((1ll << flip_q) - 1)) | (j >> flip_q << flip_q << 1);
       size_t i1 = i0 ^ flip_mask;
       uint z_phase_num = Qfutil::popcount(i0 & z_mask) % 2;

--- a/src/qfvm/statevector.hpp
+++ b/src/qfvm/statevector.hpp
@@ -1302,8 +1302,8 @@ double StateVector<real_t>::expect_pauli(string paulistr,
   if (!flip_mask) {
     size_t rsize = size_;
     double val = 0.;
-#pragma omp paraleel for reduction(+ : val)
-    for (size_t j = 0; j < rsize; ++j) {
+#pragma omp parallel for reduction(+ : val)
+    for (int j = 0; j < rsize; ++j) {
       uint z_phase_num = Qfutil::popcount(j & z_mask) % 2;
       int sign = 1 - 2 * z_phase_num;
       val += (data_[j] * std::conj(data_[j])).real() * sign;
@@ -1313,7 +1313,7 @@ double StateVector<real_t>::expect_pauli(string paulistr,
     double val = 0.;
     size_t rsize = size_ >> 1;
 #pragma omp parallel for reduction(+ : val)
-    for (size_t j = 0; j < rsize; ++j) {
+    for (int j = 0; j < rsize; ++j) {
       size_t i0 = (j & ((1ll << flip_q) - 1)) | (j >> flip_q << flip_q << 1);
       size_t i1 = i0 ^ flip_mask;
       uint z_phase_num = Qfutil::popcount(i0 & z_mask) % 2;


### PR DESCRIPTION
build job failed on windows: https://github.com/ScQ-Cloud/pyquafu/actions/runs/7552526187/job/20561548536?pr=133

- errors
  1. `statevector.hpp(1305): error C3001: 'paraleel': expected an OpenMP directive name`
  2. `statevector.hpp(1315): error C3016: 'j': index variable in OpenMP 'for' statement must have signed integral type`