### PR TITLE
fix: change to_openqasm cbit num

### DIFF
--- a/quafu/circuits/quantum_circuit.py
+++ b/quafu/circuits/quantum_circuit.py
@@ -492,7 +492,7 @@ class QuantumCircuit:
         valid_gates = QuantumGate.gate_classes #TODO:include instruction futher
         qasm = 'OPENQASM 2.0;\ninclude "qelib1.inc";\n'
         qasm += "qreg q[%d];\n" % self.num
-        qasm += "creg meas[%d];\n" % len(self.measures)
+        qasm += "creg meas[%d];\n" % self.cbits_num
         for gate in self.gates:
             if gate.name.lower() in valid_gates:
                 qasm += gate.to_qasm() + ";\n"

--- a/quafu/qfasm/qelib1.inc
+++ b/quafu/qfasm/qelib1.inc
@@ -267,3 +267,24 @@ gate c4x a,b,c,d,e
     c3x a,b,c,d;
     c3sqrtx a,b,c,e;
 }
+
+// add gate supported by pyquafu
+// cnot
+gate cnot c,t {}
+// mcx mcy mcz need more support in parser
+// ryy
+gate ryy(theta) a,b {}
+// cs
+gate cs a,b {}
+// ct
+gate ct a,b {}
+// sy
+gate sy a {}
+// w
+gate w a {}
+// sw
+gate sw a {}
+// Toffoli
+gate toffoli a,b,c {}
+// Fredkin
+gate fredkin a,b,c {}


### PR DESCRIPTION
 If we use the length of measures as the size of the cbit array, many problems will arise.
For example:
```
qc = QuantumCircuit(3)
qc.cx([0],[2])
qc.to_openqasm()
```
the qsam will be 
```OPENQASM 2.0;
include "qelib1.inc";
qreg q[4];
creg meas[1];
cx q[0],q[1];
measure q[0] -> meas[3];
```