### PR TITLE
Add __radd__ method to ParameterExpression class

### DIFF
--- a/quafu/elements/parameters.py
+++ b/quafu/elements/parameters.py
@@ -95,6 +95,9 @@ class ParameterExpression:
 
         return ParameterExpression(self.pivot, v, operands, funcs)
 
+    def __radd__(self, r):
+        return self + r
+
     def __mul__(self, r):
         operands = [opr for opr in self.operands]
         funcs = copy.deepcopy(self.funcs)


### PR DESCRIPTION
### What does this PR do?
This pull request adds the radd special method to the ParameterExpression class. This allows ParameterExpression objects to support addition with integers and other numeric types when the ParameterExpression is on the right-hand side of the + operator.
### Why is this change needed?
Previously, adding an integer to a ParameterExpression (e.g., `1 + param_expr`) would raise a TypeError because the integer's add method doesn't know how to add a ParameterExpression. By implementing radd, we define the behavior for this case and allow the addition to complete successfully by delegating to the ParameterExpression's add method.
This change improves the usability and consistency of the ParameterExpression class by supporting the commutative property of addition.

How does it work?
The radd method is called when a ParameterExpression appears on the right side of the + operator and the left operand doesn't know how to handle the addition.
In our implementation, radd simply delegates to the existing `__add__` method:
```
def __radd__(self, r):
    return self + r
 ```