### PR TITLE
ci: add pre-release only on push

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -60,6 +60,7 @@ jobs:
 
         # Used to update whl in latest draft
         -   uses: ncipollo/release-action@v1
+            if: github.event_name == 'push'
             with:
                 artifacts: dist/*.whl
                 allowUpdates: true


### PR DESCRIPTION
As `Build` workflow fails on pull request, add a condition to trigger pre-release only on push