### PR TITLE
close #192, close #194

### DIFF
--- a/quafu/algorithms/gradients/param_shift.py
+++ b/quafu/algorithms/gradients/param_shift.py
@@ -35,6 +35,8 @@ class ParamShift:
             estimator (Estimator): estimator to calculate expectation values
             params (List[float]): params to optimize
         """
+        if self._est._backend != "sim":
+            return self.grad(obs, params)
         return self.new_grad(obs, params)
 
     def _gen_param_shift_vals(self, params):
@@ -46,7 +48,6 @@ class ParamShift:
         minus_params = params - offsets * np.pi / 2
         return plus_params.tolist() + minus_params.tolist()
 
-    # TODO: delete after 0.4.1
     def grad(self, obs: Hamiltonian, params: List[float]):
         """grad.
 

--- a/quafu/circuits/quantum_circuit.py
+++ b/quafu/circuits/quantum_circuit.py
@@ -70,6 +70,8 @@ class QuantumCircuit:
         self._parameter_grads = {}
         self._variables = []
         self._has_wrap = False
+        self._def_para_name = "theta_inner"  # default parameter name prefix
+        self._para_id = 0  # current parameter index
 
     @property
     def parameterized_gates(self):
@@ -298,6 +300,17 @@ class QuantumCircuit:
         # TODO(): Support updating part of params of a single gate
         for gate, paras in zip(self.parameterized_gates, paras_list):
             gate.update_params(paras)
+
+    def angles2parameters(self):
+        """Transform all float value params to `Parameter`"""
+        for g in self.gates:
+            if all(isinstance(x, float) for x in g.paras):
+                for i in range(len(g.paras)):
+                    g.paras[i] = Parameter(
+                        f"{self._def_para_name}_{self._para_id}", value=g.paras[i]
+                    )
+                    self._para_id += 1
+        self.get_parameter_grads()
 
     def layered_circuit(self) -> np.ndarray:
         """


### PR DESCRIPTION
1. Add an  `angles2parameters`  api to enable calculating expectation using estimator.
2. If the backend is specified to use cloud systems, use old arameter shift implementation.