### PR TITLE
Add cache for estimator expectation and fix an issue

### DIFF
--- a/quafu/algorithms/estimator.py
+++ b/quafu/algorithms/estimator.py
@@ -33,6 +33,7 @@ def execute_circuit(circ: QuantumCircuit, observables: Hamiltonian):
     return sum(expectations)
 
 
+# TODO: cache measure results values and reuse for expectation calculation
 class Estimator:
     """Estimate expectation for quantum circuits and observables"""
 
@@ -86,7 +87,7 @@ class Estimator:
         # TODO(zhaoyilun):
         #   investigate the best implementation for calculating
         #   expectation on real devices.
-        obslist = observables.to_legacy_quafu_pauli_list()
+        obslist = observables.to_pauli_list()
 
         # save input circuit
         inputs = copy.deepcopy(self._circ.gates)

--- a/quafu/algorithms/gradients/vjp.py
+++ b/quafu/algorithms/gradients/vjp.py
@@ -66,6 +66,7 @@ def jacobian(
     Args:
         circ (QuantumCircuit): circ
         params_input (np.ndarray): params_input, with shape [batch_size, num_params]
+        estimator (Estimator): estimator for calculating expectations.
     """
     batch_size, num_params = params_input.shape
     obs_list = _generate_expval_z(circ.num)

--- a/quafu/algorithms/gradients/vjp.py
+++ b/quafu/algorithms/gradients/vjp.py
@@ -51,7 +51,8 @@ def run_circ(
         estimator = Estimator(circ, backend=backend)
     if params is None:
         params = [g.paras for g in circ.parameterized_gates]
-    output = [estimator.run(obs, params) for obs in obs_list]
+    output = [estimator.run(obs, params, cache_key="00") for obs in obs_list]
+    estimator.clear_cache()
     return np.array(output)
 
 
@@ -67,6 +68,20 @@ def jacobian(
         circ (QuantumCircuit): circ
         params_input (np.ndarray): params_input, with shape [batch_size, num_params]
         estimator (Estimator): estimator for calculating expectations.
+
+
+    Notes:
+        Since now we only use Z-axis expectations for all qubits as outputs
+        i.e., the observable is Z0,Z1,..., for the same circuit we only need
+        to send one task and the execution results can be used for calculating
+        expectations for all these Pauli-Z operators.
+
+        Thus we use cache here, to uniquely identity a circuit, we use the id
+        of parameters. Here we have batch_size * num_parameters * 2 lists of
+        parameters. Let batch_size be $M$, $N = num_parameters * 2$,
+
+        let $i\\in\\[0, M-1\\]$, $j\\in\\[0, M-1\\]$, the cache_key is then set
+        to be "{i}{j}"
     """
     batch_size, num_params = params_input.shape
     obs_list = _generate_expval_z(circ.num)
@@ -76,10 +91,16 @@ def jacobian(
     calc_grad = ParamShift(estimator)
     output = np.zeros((batch_size, num_outputs, num_params))
     for i in range(batch_size):
+        # Same circuit, i.e., measurement results with the same parameters may be reused
+        cache_key_prefix = str(i)
         grad_list = [
-            np.array(calc_grad(obs, params_input[i, :].tolist())) for obs in obs_list
+            np.array(
+                calc_grad(obs, params_input[i, :].tolist(), cache_key=cache_key_prefix)
+            )
+            for obs in obs_list
         ]
         output[i, :, :] = np.stack(grad_list)
+    estimator.clear_cache()
     return output
 
 
@@ -118,13 +139,3 @@ def compute_vjp(jac: np.ndarray, dy: np.ndarray):
     vjp = np.einsum("ijk,ij->ik", jac, dy)
 
     return vjp
-
-
-# class QNode:
-#     """Quantum node which essentially wraps the execution of a quantum circuit"""
-#
-#     def __init__(self, circ: QuantumCircuit) -> None:
-#         self._circ = circ
-#
-#     def __call__(self):
-#         return execu

--- a/quafu/algorithms/hamiltonian.py
+++ b/quafu/algorithms/hamiltonian.py
@@ -124,14 +124,20 @@ class Hamiltonian:
 
         return mat
 
-    # TODO(zhaoyilun): delete this in the future
-    def to_legacy_quafu_pauli_list(self):
-        """Transform to legacy quafu pauli list format,
-        this is a temperal function and should be deleted later"""
+    def to_pauli_list(self):
+        """
+        Transform to pauli list format for ease of
+        expectation calculation on cloud systems
+
+        Currently coeff does not make sense because expectation calculation
+        on cloud systems does not support it
+
+        Examples:
+            ("Z0 Z1 Z2 Z3") -> ["ZZZZ", [0, 1, 2, 3]]
+        """
         res = []
         for pauli_str in self.paulis:
-            for i, pos in enumerate(pauli_str.pos):
-                res.append([pauli_str.paulistr[i], [pos]])
+            res.append([pauli_str.paulistr, pauli_str.pos])
         return res
 
 

--- a/quafu/results/results.py
+++ b/quafu/results/results.py
@@ -29,8 +29,9 @@ class ExecResult(Result):
             0: "In Queue",
             1: "Running",
             2: "Completed",
-            "Canceled": 3,
+            3: "Canceled",
             4: "Failed",
+            5: "Pending",
         }
         self.taskid = input_dict["task_id"]
         self.taskname = input_dict["task_name"]

--- a/tests/quafu/algorithms/estimator_test.py
+++ b/tests/quafu/algorithms/estimator_test.py
@@ -70,7 +70,7 @@ class TestEstimator:
         estimator = Estimator(circ, backend="ScQ-P10")
         expectation = estimator.run(test_ising, None)
         task = Task()
-        res_org, obsexp_org = task.submit(circ, test_ising.to_legacy_quafu_pauli_list())
+        res_org, obsexp_org = task.submit(circ, test_ising.to_pauli_list())
         assert expectation == sum(obsexp_org)
 
     @pytest.mark.skipif(


### PR DESCRIPTION
1. Implement a cache mechanism to reduce expectation calculation for QNN
2. A status is missing is results `task_status_map`