### PR TITLE
ci: optimize ci workflow, close #200

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -3,14 +3,18 @@ name: pre-commit
 on:
     pull_request:
     push:
-        branches: [main]
+        branches: [master]
 
 jobs:
     pre-commit:
         runs-on: ubuntu-latest
         steps:
         -   uses: actions/checkout@v3
-        -   uses: actions/setup-python@v3
+        -   uses: actions/setup-python@v4
             with:
                 python-version: '3.10'
-        -   uses: pre-commit/action@v3.0.0
+        -   uses: actions/cache@v3
+            with:
+                path: ~/.cache/pre-commit/
+                key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+        -   uses: pre-commit/action@v3.0.1

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,7 +1,7 @@
 name: Unit test
 on:
-    push:
     pull_request:
+    push:
         branches: [master]
 jobs:
     unnittest:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -11,11 +11,89 @@ on:
         types: [submitted, edited]
     workflow_dispatch:
 
-
-
 jobs:
-    build_wheels:
-        name: Build python wheels
+    single_platform_build:
+        name: Build python wheel on linux
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master' || github.event_name == 'pull_request' && github.base_ref == 'master'
+        strategy:
+            matrix:
+                os-arch: [manylinux_x86_64]
+                python-version: ['3.10']
+                include:
+                -   os-arch: manylinux_x86_64
+                    os: ubuntu-20.04
+        runs-on: ${{ matrix.os }}
+
+        env:
+            PYTHON: ${{ matrix.python-version }}
+            TWINE_USERNAME: __token__
+
+        steps:
+        -   uses: actions/checkout@v3
+
+        # Install dependencies including ccache and g++-10
+        -   name: Install dependencies
+            run: |
+                sudo apt-get update
+                sudo apt-get install -y software-properties-common
+                sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+                sudo apt-get update
+                sudo apt-get install -y ccache gcc-10 g++-10
+
+        # Set up Python
+        -   uses: actions/setup-python@v3
+            with:
+                python-version: ${{ matrix.python-version }}
+
+        # Set ccache and compiler environment variables
+        -   name: Configure ccache and g++-10
+            run: |
+                export CC="ccache gcc-10"
+                export CXX="ccache g++-10"
+                export CCACHE_DIR=~/.ccache
+                ccache -z  # Zero statistics before the build
+            shell: bash
+
+        # Restore ccache cache
+        -   uses: actions/cache@v3
+            id: ccache-cache
+            with:
+                path: ~/.ccache
+                key: ccache-${{ runner.os }}-${{ hashFiles('src/**/*.hpp', 'src/**/*.cpp', 'src/**/*.h', 'src/**/*.cuh') }}
+                restore-keys: |
+                    ccache-${{ runner.os }}-
+
+        # Install Python dependencies
+        -   name: Install Python dependencies
+            run: python -m pip install pybind11 scikit-build build twine pytest
+
+        # Build wheels
+        -   name: Build wheels using python build
+            run: |
+                export CC="ccache gcc-10"
+                export CXX="ccache g++-10"
+                python -m build --wheel
+            shell: bash
+
+        # Display ccache statistics
+        -   name: Display ccache statistics
+            run: ccache -s
+
+        # Upload compiled artifacts to pre-release
+        -   uses: ncipollo/release-action@v1
+            if: github.event_name == 'push'
+            with:
+                artifacts: dist/*.whl
+                allowUpdates: true
+                tag: pre-release
+                draft: true
+                prerelease: true
+                token: ${{ secrets.GITHUB_TOKEN }}
+
+
+    all_platform_build_and_publish_package:
+        name: Build python wheels on all platforms
+        if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
         strategy:
             matrix:
                 os-arch: [manylinux_x86_64, win_amd64, macosx_x86_64, macosx_arm64]
@@ -40,31 +118,36 @@ jobs:
         steps:
         -   uses: actions/checkout@v3
 
-      # Used to host cibuildwheel
+
+
+        # Set up Python
         -   uses: actions/setup-python@v3
             with:
                 python-version: ${{ matrix.python-version }}
 
-        -   name: Install dependence
+        # Set ccache environment variables
+        -   name: Configure ccache
+            run: |
+                export CC="ccache gcc"
+                export CXX="ccache g++"
+                export CCACHE_DIR=~/.ccache
+                ccache -z  # Zero statistics before the build
+            shell: bash
+
+        # Install Python dependencies
+        -   name: Install Python dependencies
             run: python -m pip install pybind11 cibuildwheel scikit-build twine pytest
 
+        # Build wheels
         -   name: Build wheels
             run: python -m cibuildwheel --output-dir dist
+            shell: bash
 
+
+        # Publish package
         -   name: Publish package
             run: python -m twine upload dist/*.whl
             if: ${{ contains(github.ref, '/tags/') }}
             env:
                 TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
                 TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-
-        # Used to update whl in latest draft
-        -   uses: ncipollo/release-action@v1
-            if: github.event_name == 'push'
-            with:
-                artifacts: dist/*.whl
-                allowUpdates: true
-                tag: pre-release
-                draft: true
-                prerelease: true
-                token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 改动

- 当push到非master分支的时候，只运行commit-lint一个action。
- 当push/pr到master的时候，只在linux下进行构建，并通过ccache缓存c++编译产出。
- 当push一个新的tag时，在全平台构建，此时仍然和以前一样采用cibuildwheel进行构建，由于cibuildwheel在隔离的容器环境中构建，而且包含windows, macos等平台，想要使用ccache比较麻烦。且考虑到只有发布版本的时候才会全平台构建，这时感觉不需要ccache了。
- 给pre-commit增加了cache。

## 效果

- pre-commit action的日志：https://github.com/Zhaoyilunnn/pyquafu/actions/runs/12176486795/job/33962337394
- wheels action的日志：https://github.com/Zhaoyilunnn/pyquafu/actions/runs/12176486818/job/33962338169