### PR TITLE
fix: update ubuntu runner version

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,70 +1,68 @@
 name: Build
 
 on:
-    push:
-        branches:
-        -   master
-        tags:
-        -   v*
-    pull_request:
-    pull_request_review:
-        types: [submitted, edited]
-    workflow_dispatch:
-
-
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+  pull_request:
+  pull_request_review:
+    types: [submitted, edited]
+  workflow_dispatch:
 
 jobs:
-    build_wheels:
-        name: Build python wheels
-        strategy:
-            matrix:
-                os-arch: [manylinux_x86_64, win_amd64, macosx_x86_64, macosx_arm64]
-                python-version: ['3.10']
-                cibw-python: [cp38, cp39, cp310, cp311, cp312]
-                include:
-                -   os-arch: manylinux_x86_64
-                    os: ubuntu-20.04
-                -   os-arch: win_amd64
-                    os: windows-2019
-                -   os-arch: macosx_x86_64
-                    os: macos-13
-                -   os-arch: macosx_arm64
-                    os: macos-13
-        runs-on: ${{ matrix.os }}
+  build_wheels:
+    name: Build python wheels
+    strategy:
+      matrix:
+        os-arch: [manylinux_x86_64, win_amd64, macosx_x86_64, macosx_arm64]
+        python-version: ["3.10"]
+        cibw-python: [cp38, cp39, cp310, cp311, cp312]
+        include:
+          - os-arch: manylinux_x86_64
+            os: ubuntu-latest
+          - os-arch: win_amd64
+            os: windows-2019
+          - os-arch: macosx_x86_64
+            os: macos-13
+          - os-arch: macosx_arm64
+            os: macos-13
+    runs-on: ${{ matrix.os }}
 
-        env:
-            CIBW_BUILD: ${{ matrix.cibw-python }}-${{ matrix.os-arch }}
-            PYTHON: ${{ matrix.python-version }}
-            TWINE_USERNAME: __token__
+    env:
+      CIBW_BUILD: ${{ matrix.cibw-python }}-${{ matrix.os-arch }}
+      PYTHON: ${{ matrix.python-version }}
+      TWINE_USERNAME: __token__
 
-        steps:
-        -   uses: actions/checkout@v3
+    steps:
+      - uses: actions/checkout@v3
 
       # Used to host cibuildwheel
-        -   uses: actions/setup-python@v3
-            with:
-                python-version: ${{ matrix.python-version }}
+      - uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
 
-        -   name: Install dependence
-            run: python -m pip install pybind11 cibuildwheel scikit-build twine pytest
+      - name: Install dependence
+        run: python -m pip install pybind11 cibuildwheel scikit-build twine pytest
 
-        -   name: Build wheels
-            run: python -m cibuildwheel --output-dir dist
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir dist
 
-        -   name: Publish package
-            run: python -m twine upload dist/*.whl
-            if: ${{ contains(github.ref, '/tags/') }}
-            env:
-                TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-                TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+      - name: Publish package
+        run: python -m twine upload dist/*.whl
+        if: ${{ contains(github.ref, '/tags/') }}
+        env:
+          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
 
-        # Used to update whl in latest draft
-        -   uses: ncipollo/release-action@v1
-            if: github.event_name == 'push'
-            with:
-                artifacts: dist/*.whl
-                allowUpdates: true
-                tag: pre-release
-                draft: true
-                prerelease: true
-                token: ${{ secrets.GITHUB_TOKEN }}
+      # Used to update whl in latest draft
+      - uses: ncipollo/release-action@v1
+        if: github.event_name == 'push'
+        with:
+          artifacts: dist/*.whl
+          allowUpdates: true
+          tag: pre-release
+          draft: true
+          prerelease: true
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
According to https://github.com/ScQ-Cloud/pyquafu/actions/runs/14856088211/job/41709699042

The Ubuntu 20.04 LTS runner has been removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101

Thus we need to update the workflow