### PR TITLE
ci: update to windows-latest and macos-latest

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os-arch: [manylinux_x86_64, win_amd64, macosx_x86_64, macosx_arm64]
-        python-version: ["3.12"]
+        python-version: ["3.11"]
         cibw-python: [cp38, cp39, cp310, cp311, cp312]
         include:
           - os-arch: manylinux_x86_64

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -25,7 +25,7 @@ jobs:
           - os-arch: win_amd64
             os: windows-latest
           - os-arch: macosx_x86_64
-            os: macos-latest-large
+            os: macos-13
           - os-arch: macosx_arm64
             os: macos-latest
     runs-on: ${{ matrix.os }}
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v5
 
       # Used to host cibuildwheel
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os-arch: [manylinux_x86_64, win_amd64, macosx_x86_64, macosx_arm64]
-        python-version: ["3.11"]
+        python-version: ["3.10"]
         cibw-python: [cp38, cp39, cp310, cp311, cp312]
         include:
           - os-arch: manylinux_x86_64

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,7 +1,6 @@
 name: Build
 
 on:
-
   push:
     branches:
       - master
@@ -24,11 +23,11 @@ jobs:
           - os-arch: manylinux_x86_64
             os: ubuntu-latest
           - os-arch: win_amd64
-            os: windows-2019
+            os: windows-latest
           - os-arch: macosx_x86_64
-            os: macos-13
+            os: macos-latest-large
           - os-arch: macosx_arm64
-            os: macos-13
+            os: macos-latest
     runs-on: ${{ matrix.os }}
 
     env:
@@ -38,7 +37,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
 
       # Used to host cibuildwheel
       - uses: actions/setup-python@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os-arch: [manylinux_x86_64, win_amd64, macosx_x86_64, macosx_arm64]
         python-version: ["3.10"]
-        cibw-python: [cp38, cp39, cp310, cp311, cp312]
+        cibw-python: [cp39, cp310, cp311, cp312, cp313]
         include:
           - os-arch: manylinux_x86_64
             os: ubuntu-latest

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os-arch: [manylinux_x86_64, win_amd64, macosx_x86_64, macosx_arm64]
-        python-version: ["3.10"]
+        python-version: ["3.12"]
         cibw-python: [cp38, cp39, cp310, cp311, cp312]
         include:
           - os-arch: manylinux_x86_64
@@ -36,10 +36,10 @@ jobs:
       TWINE_USERNAME: __token__
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       # Used to host cibuildwheel
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,8 @@ set ( PRJ_INCLUDE_DIRS )
 
 # openmp
 if (${CMAKE_HOST_SYSTEM_NAME} MATCHES Darwin)
-    execute_process(COMMAND brew install libomp)
-    execute_process(COMMAND brew --prefix OUTPUT_VARIABLE HOMEBREW_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE)
+  execute_process(COMMAND brew install libomp)
+  execute_process(COMMAND brew --prefix OUTPUT_VARIABLE HOMEBREW_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE)
 	list ( APPEND PRJ_LIBRARIES ${HOMEBREW_PREFIX}/opt/libomp/lib )
 	list ( APPEND PRJ_INCLUDE_DIRS ${HOMEBREW_PREFIX}/opt/libomp/include )
 else()


### PR DESCRIPTION
windows-2019 已经退休 https://github.com/actions/runner-images/issues/12045
python包发布版本从 3.8-3.12 升级为 3.9-3.13